### PR TITLE
fix(parser): Wrong negative sign precedence was causing math errors (#6)

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1385,9 +1385,13 @@ export class Parser {
         }
 
         function prefixUnary(): Expression {
-            if (match(Lexeme.Not, Lexeme.Minus, Lexeme.Plus)) {
+            if (match(Lexeme.Not)) {
                 let operator = previous();
                 let right = relational();
+                return new Expr.Unary(operator, right);
+            } else if (match(Lexeme.Minus, Lexeme.Plus)) {
+                let operator = previous();
+                let right = prefixUnary();
                 return new Expr.Unary(operator, right);
             }
 

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -75,6 +75,16 @@ describe("end to end syntax", () => {
         ]);
     });
 
+    test("negative-precedence.brs", async () => {
+        await execute([resourceFile("negative-precedence.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
+            "0000",
+            "0",
+            "foo is not 1",
+        ]);
+    });
+
     test("assignment.brs", async () => {
         await execute([resourceFile("assignment.brs")], outputStreams);
 

--- a/test/e2e/resources/negative-precedence.brs
+++ b/test/e2e/resources/negative-precedence.brs
@@ -1,0 +1,15 @@
+Sub Main()
+    x = 96
+    y = 56
+    w = 1088
+    h = 608
+    Offset(-x + 96, -y + 56, -w + 1088, -h + 608)
+    print -1000 +1000
+    foo = 5
+    if not foo = 1
+        print "foo is not 1"
+    end if
+End Sub
+Sub Offset(x, y, w, h)
+    print x.toStr() + y.toStr() + w.toStr() + h.toStr()
+End Sub


### PR DESCRIPTION
There was a change done to fix another issue that caused this side effect (see bug for details)