### PR TITLE
fix(parser,lexer) Optional chaining implementation side effect #30

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -239,7 +239,23 @@ export class Lexer {
                     addToken(Lexeme.Semicolon);
                     break;
                 case "?":
-                    addToken(Lexeme.Print);
+                    switch (peek()) {
+                        case ".":
+                            advance();
+                            addToken(Lexeme.Dot);
+                            break;
+                        case "(":
+                            advance();
+                            addToken(Lexeme.LeftParen);
+                            break;
+                        case "[":
+                            advance();
+                            addToken(Lexeme.LeftBrace);
+                            break;
+                        default:
+                            addToken(Lexeme.Print);
+                            break;
+                    }
                     break;
                 case "<":
                     switch (peek()) {
@@ -302,7 +318,7 @@ export class Lexer {
                 case " ":
                 case "\r":
                 case "\t":
-                    // ignore whitespace; indentation isn't signficant in BrightScript
+                    // ignore whitespace; indentation isn't significant in BrightScript
                     break;
                 case "\n":
                     // consecutive newlines aren't significant, because they're just blank lines

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -534,7 +534,6 @@ export class Parser {
                     Lexeme.Newline,
                     Lexeme.Colon,
                     Lexeme.Eof,
-                    Lexeme.Identifier,
                     ...additionalterminators
                 );
             }
@@ -1420,8 +1419,6 @@ export class Parser {
             while (true) {
                 if (match(Lexeme.LeftParen)) {
                     expr = finishCall(expr);
-                } else if (match(Lexeme.Print)) {
-                    // doing nothing as invalid check was before
                 } else if (match(Lexeme.LeftSquare)) {
                     indexedGet();
                 } else if (match(Lexeme.Dot)) {

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -131,6 +131,8 @@ describe("end to end syntax", () => {
             "foo is not < 2",
             "foo is not < 2 and not > 2",
             "#481 fixed",
+            "2",
+            "5",
         ]);
     });
 

--- a/test/e2e/resources/conditionals.brs
+++ b/test/e2e/resources/conditionals.brs
@@ -123,13 +123,22 @@ sub main()
         print "foo is not < 2 and not > 2"
     end if
 
-    test_481()
+    test_issue_481()
+    test_issue_30()
 end sub
 
-' MWE from https://github.com/rokucommunity/brs/issues/481
-sub test_481()
+' MWE from https://github.com/sjbarag/brs/issues/481
+sub test_issue_481()
     nop = sub() : end sub
 
     if false then nop(): print "#481 still repro's": return
     print "#481 fixed"
 end sub
+
+' Test for https://github.com/rokucommunity/brs/issues/30
+function test_issue_30()
+    testA = ["apple", 2, "banana", "orange", 5, "grape", "pear"]
+    for fruit = 0 to testA.count()-1
+        if type(testA[fruit]).inStr(0,"String") = -1 ? testA[fruit]
+    next
+end function

--- a/test/parser/expression/Indexing.test.js
+++ b/test/parser/expression/Indexing.test.js
@@ -33,8 +33,7 @@ describe("parser indexing", () => {
                 identifier("_"),
                 token(Lexeme.Equal, "="),
                 identifier("bar"),
-                token(Lexeme.Print, "?"),
-                token(Lexeme.Dot, "."),
+                token(Lexeme.Dot, "?."),
                 identifier("foo"),
                 EOF,
             ]);
@@ -48,8 +47,7 @@ describe("parser indexing", () => {
                 identifier("_"),
                 token(Lexeme.Equal, "="),
                 token(Lexeme.Invalid, "invalid", BrsInvalid.Instance),
-                token(Lexeme.Print, "?"),
-                token(Lexeme.Dot, "."),
+                token(Lexeme.Dot, "?."),
                 identifier("bar"),
                 EOF,
             ]);


### PR DESCRIPTION
The optional chaining implementation was not done correctly, it affected the parsing of in-line `if` with the `?` (print) statement.