### PR TITLE
feat(components): Implemented missing `ifEnum` methods in `roArray` and `roAssociativeArray`

### DIFF
--- a/src/brsTypes/components/RoArray.ts
+++ b/src/brsTypes/components/RoArray.ts
@@ -1,9 +1,8 @@
+import { BrsType, isBrsString, isBrsNumber, Int32 } from "..";
 import { BrsValue, ValueKind, BrsString, BrsBoolean, BrsInvalid, Comparable } from "../BrsType";
-import { BrsType, isBrsString, isBrsNumber, isBrsBoolean } from "..";
 import { BrsComponent, BrsIterable } from "./BrsComponent";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
-import { Int32 } from "../Int32";
 import { RoAssociativeArray } from "./RoAssociativeArray";
 
 /**
@@ -28,7 +27,7 @@ function getTypeSortIndex(a: BrsType): number {
 }
 
 /**
- * Sorts two BrsTypes in the order that ROku would sort them
+ * Sorts two BrsTypes in the order that Roku would sort them
  * @param originalArray A copy of the original array. Used to get the order of items
  * @param a
  * @param b
@@ -82,11 +81,13 @@ function sortCompare(
 
 export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
     readonly kind = ValueKind.Object;
-    private elements: BrsType[];
+    elements: BrsType[];
+    enumIndex: number;
 
     constructor(elements: BrsType[]) {
         super("roArray");
         this.elements = elements;
+        this.enumIndex = elements.length ? 0 : -1;
         this.registerMethods({
             ifArray: [
                 this.peek,
@@ -99,9 +100,11 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
                 this.clear,
                 this.append,
             ],
+            ifArrayGet: [this.getEntry],
+            ifArraySet: [this.setEntry],
             ifArrayJoin: [this.join],
             ifArraySort: [this.sort, this.sortBy, this.reverse],
-            ifEnum: [this.isEmpty],
+            ifEnum: [this.isEmpty, this.isNext, this.next, this.reset],
         });
     }
 
@@ -132,33 +135,80 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
 
     get(index: BrsType) {
         switch (index.kind) {
+            case ValueKind.Float:
+                return this.getElements()[Math.trunc(index.getValue())] || BrsInvalid.Instance;
             case ValueKind.Int32:
                 return this.getElements()[index.getValue()] || BrsInvalid.Instance;
             case ValueKind.String:
                 return this.getMethod(index.value) || BrsInvalid.Instance;
             default:
                 throw new Error(
-                    "Array indexes must be 32-bit integers, or method names must be strings"
+                    "Array indexes must be 32-bit integers or Float, or method names must be strings"
                 );
         }
     }
 
     set(index: BrsType, value: BrsType) {
-        if (index.kind !== ValueKind.Int32) {
-            throw new Error("Array indexes must be 32-bit integers");
+        if (index.kind === ValueKind.Int32 || index.kind === ValueKind.Float) {
+            this.elements[Math.trunc(index.getValue())] = value;
+        } else {
+            throw new Error("Array indexes must be 32-bit integers or Float");
         }
-
-        this.elements[index.getValue()] = value;
-
         return BrsInvalid.Instance;
     }
 
+    getNext() {
+        const index = this.enumIndex;
+        if (index >= 0) {
+            this.enumIndex++;
+            if (this.enumIndex >= this.elements.length) {
+                this.enumIndex = -1;
+            }
+        }
+        return this.elements[index];
+    }
+        
+    updateNext() {
+        const hasItems = this.elements.length > 0;
+        if (this.enumIndex === -1 && hasItems) {
+            this.enumIndex = 0;
+        } else if (this.enumIndex >= this.elements.length || !hasItems) {
+            this.enumIndex = -1;
+        }
+    }
+
+    aaCompare(
+        fieldName: BrsString,
+        flags: BrsString,
+        a: RoAssociativeArray,
+        b: RoAssociativeArray
+    ) {
+        let compare = 0;
+        const originalArrayCopy = [...this.elements];
+        const caseInsensitive = flags.toString().indexOf("i") > -1;
+        const aHasField = a.elements.has(fieldName.toString().toLowerCase());
+        const bHasField = b.elements.has(fieldName.toString().toLowerCase());
+        if (aHasField && bHasField) {
+            const valueA = a.get(fieldName);
+            const valueB = b.get(fieldName);
+            compare = sortCompare(originalArrayCopy, valueA, valueB, caseInsensitive);
+        } else if (aHasField) {
+            // assocArray with fields come before assocArrays without
+            compare = -1;
+        } else if (bHasField) {
+            // assocArray with fields come before assocArrays without
+            compare = 1;
+        }
+        return compare;
+    }
+
+    // ifArray
     private peek = new Callable("peek", {
         signature: {
             args: [],
             returns: ValueKind.Dynamic,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             return this.elements[this.elements.length - 1] || BrsInvalid.Instance;
         },
     });
@@ -168,8 +218,10 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Dynamic,
         },
-        impl: (interpreter: Interpreter) => {
-            return this.elements.pop() || BrsInvalid.Instance;
+        impl: (_: Interpreter) => {
+            const removed = this.elements.pop();
+            this.updateNext();
+            return removed || BrsInvalid.Instance;
         },
     });
 
@@ -178,8 +230,9 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("talue", ValueKind.Dynamic)],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter, tvalue: BrsType) => {
+        impl: (_: Interpreter, tvalue: BrsType) => {
             this.elements.push(tvalue);
+            this.updateNext();
             return BrsInvalid.Instance;
         },
     });
@@ -189,8 +242,10 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Dynamic,
         },
-        impl: (interpreter: Interpreter) => {
-            return this.elements.shift() || BrsInvalid.Instance;
+        impl: (_: Interpreter) => {
+            const removed = this.elements.shift();
+            this.updateNext();
+            return removed || BrsInvalid.Instance;
         },
     });
 
@@ -199,8 +254,9 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("tvalue", ValueKind.Dynamic)],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter, tvalue: BrsType) => {
+        impl: (_: Interpreter, tvalue: BrsType) => {
             this.elements.unshift(tvalue);
+            this.updateNext();
             return BrsInvalid.Instance;
         },
     });
@@ -210,12 +266,12 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("index", ValueKind.Int32)],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter, index: Int32) => {
+        impl: (_: Interpreter, index: Int32) => {
             if (index.lessThan(new Int32(0)).toBoolean()) {
                 return BrsBoolean.False;
             }
-
-            let deleted = this.elements.splice(index.getValue(), 1);
+            const deleted = this.elements.splice(index.getValue(), 1);
+            this.updateNext();
             return BrsBoolean.from(deleted.length > 0);
         },
     });
@@ -225,7 +281,7 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Int32,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             return new Int32(this.elements.length);
         },
     });
@@ -235,8 +291,9 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             this.elements = [];
+            this.enumIndex = -1;
             return BrsInvalid.Instance;
         },
     });
@@ -246,9 +303,8 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("array", ValueKind.Object)],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter, array: BrsComponent) => {
+        impl: (_: Interpreter, array: BrsComponent) => {
             if (!(array instanceof RoArray)) {
-                // TODO: validate against RBI
                 return BrsInvalid.Instance;
             }
 
@@ -256,10 +312,39 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
                 ...this.elements,
                 ...array.elements.filter((element) => !!element), // don't copy "holes" where no value exists
             ];
-
+            this.updateNext();
             return BrsInvalid.Instance;
         },
     });
+
+    // ifArrayGet
+    private getEntry = new Callable("getEntry", {
+        signature: {
+            args: [new StdlibArgument("index", ValueKind.Dynamic)],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (_: Interpreter, index: BrsType) => {
+            if (index.kind === ValueKind.Int32 || index.kind === ValueKind.Float) {
+                return this.elements[Math.trunc(index.getValue())] || BrsInvalid.Instance;
+            }
+            return BrsInvalid.Instance;
+        },
+    });
+
+    // ifArraySet
+    private setEntry = new Callable("setEntry", {
+        signature: {
+            args: [
+                new StdlibArgument("index", ValueKind.Dynamic),
+                new StdlibArgument("tvalue", ValueKind.Dynamic),
+            ],
+            returns: ValueKind.Void,
+        },
+        impl: (_: Interpreter, index: BrsType, tvalue: BrsType) => {
+            return this.set(index, tvalue);
+        },
+    });
+
     // ifArrayJoin
     private join = new Callable("join", {
         signature: {
@@ -313,29 +398,11 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             if (flags.toString().match(/([^ir])/g) != null) {
                 interpreter.stderr.write("roArray.SortBy: Flags contains invalid option(s).\n");
             } else {
-                const caseInsensitive = flags.toString().indexOf("i") > -1;
                 const originalArrayCopy = [...this.elements];
                 this.elements = this.elements.sort((a, b) => {
                     let compare = 0;
                     if (a instanceof RoAssociativeArray && b instanceof RoAssociativeArray) {
-                        const aHasField = a.elements.has(fieldName.toString().toLowerCase());
-                        const bHasField = b.elements.has(fieldName.toString().toLowerCase());
-                        if (aHasField && bHasField) {
-                            const valueA = a.get(fieldName);
-                            const valueB = b.get(fieldName);
-                            compare = sortCompare(
-                                originalArrayCopy,
-                                valueA,
-                                valueB,
-                                caseInsensitive
-                            );
-                        } else if (aHasField) {
-                            // assocArray with fields come before assocArrays without
-                            compare = -1;
-                        } else if (bHasField) {
-                            // assocArray with fields come before assocArrays without
-                            compare = 1;
-                        }
+                        compare = this.aaCompare(fieldName, flags, a, b);
                     } else if (a !== undefined && b !== undefined) {
                         compare = sortCompare(originalArrayCopy, a, b, false, false);
                     }
@@ -354,19 +421,55 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter, separator: BrsString) => {
+        impl: (_: Interpreter, separator: BrsString) => {
             this.elements = this.elements.reverse();
             return BrsInvalid.Instance;
         },
     });
     // ifEnum
+
+    /** Checks whether the array contains no elements. */
     private isEmpty = new Callable("isEmpty", {
         signature: {
             args: [],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             return BrsBoolean.from(this.elements.length === 0);
+        },
+    });
+
+    /** Checks whether the current position is not past the end of the enumeration. */
+    private isNext = new Callable("isNext", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            return BrsBoolean.from(this.enumIndex >= 0);
+        },
+    });
+
+    /** Resets the current position to the first element of the enumeration. */
+    private reset = new Callable("reset", {
+        signature: {
+            args: [],
+            returns: ValueKind.Void,
+        },
+        impl: (_: Interpreter) => {
+            this.enumIndex = this.elements.length > 0 ? 0 : -1;
+            return BrsInvalid.Instance;
+        },
+    });
+
+    /** Increments the position of an enumeration. */
+    private next = new Callable("next", {
+        signature: {
+            args: [],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (_: Interpreter) => {
+            return this.getNext() ?? BrsInvalid.Instance;
         },
     });
 }

--- a/test/brsTypes/components/RoAssociativeArray.test.js
+++ b/test/brsTypes/components/RoAssociativeArray.test.js
@@ -38,11 +38,11 @@ describe("RoAssociativeArray", () => {
 {
     array: <Component: roArray>
     associative-array: <Component: roAssociativeArray>
-    node: <Component: roSGNode:Node>
     boolean: true
-    string: "a string"
-    number: -1
     invalid: invalid
+    node: <Component: roSGNode:Node>
+    number: -1
+    string: "a string"
 }`
             );
         });

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -96,14 +96,19 @@ describe("end to end brightscript functions", () => {
         expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "testing roArray ifEnum",
             "isNext Not Empty:",
+            " ",
             "true",
             "isEmpty:",
+            " ",
             "true",
             "isNext Empty:",
+            " ",
             "false",
             "isNext before Reset:",
+            " ",
             "true",
             "isNext after Reset:",
+            " ",
             "true",
             "a",
             "b",
@@ -111,8 +116,10 @@ describe("end to end brightscript functions", () => {
             "c",
             "testing AA ifEnum",
             "isNext before Reset:",
+            " ",
             "true",
             "isNext after Reset:",
+            " ",
             "true",
             "a",
             "b",
@@ -121,12 +128,16 @@ describe("end to end brightscript functions", () => {
             "9",
             "x",
             "isEmpty:",
+            " ",
             "false",
             "isNext Empty:",
+            " ",
             "false",
             "isNext before Reset:",
+            " ",
             "true",
             "isNext after Reset:",
+            " ",
             "true",
             "a",
             "b",
@@ -136,8 +147,8 @@ describe("end to end brightscript functions", () => {
             "b",
             "c",
             "d",
-            "9",
             "x",
+            "9",
         ]);
     });
 
@@ -284,8 +295,8 @@ describe("end to end brightscript functions", () => {
                 "getAttributes() = ",
                 `<Component: roAssociativeArray> =\n` +
                     `{\n` +
-                    `    id: "someId"\n` +
                     `    attr1: "0"\n` +
+                    `    id: "someId"\n` +
                     `}`,
                 'getNamedElementsCi("child1") count = ',
                 "2",

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -90,6 +90,57 @@ describe("end to end brightscript functions", () => {
         ]);
     });
 
+    test("components/ifEnum.brs", async () => {
+        await execute([resourceFile("components", "ifEnum.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
+            "testing roArray ifEnum",
+            "isNext Not Empty:",
+            "true",
+            "isEmpty:",
+            "true",
+            "isNext Empty:",
+            "false",
+            "isNext before Reset:",
+            "true",
+            "isNext after Reset:",
+            "true",
+            "a",
+            "b",
+            "c",
+            "c",
+            "testing AA ifEnum",
+            "isNext before Reset:",
+            "true",
+            "isNext after Reset:",
+            "true",
+            "a",
+            "b",
+            "c",
+            "d",
+            "9",
+            "x",
+            "isEmpty:",
+            "false",
+            "isNext Empty:",
+            "false",
+            "isNext before Reset:",
+            "true",
+            "isNext after Reset:",
+            "true",
+            "a",
+            "b",
+            "c",
+            "Reset()",
+            "a",
+            "b",
+            "c",
+            "d",
+            "9",
+            "x",
+        ]);
+    });
+
     test("components/roDateTime.brs", async () => {
         await execute([resourceFile("components", "roDateTime.brs")], outputStreams);
 

--- a/test/e2e/resources/components/ifEnum.brs
+++ b/test/e2e/resources/components/ifEnum.brs
@@ -6,17 +6,17 @@ end sub
 sub testArray()
     print "testing roArray ifEnum"
     arr = [1,2,3]
-    print "isNext Not Empty: "; arr.isNext()
+    print "isNext Not Empty:"; arr.isNext()
     arr.clear()
-    print "isEmpty: "; arr.isEmpty()
-    print "isNext Empty: "; arr.isNext()
+    print "isEmpty:"; arr.isEmpty()
+    print "isNext Empty:"; arr.isNext()
     arr.push("a")
     arr.push("b")
     arr.push("c")
     arr.push("d")
-    print "isNext before Reset: "; arr.isNext()
+    print "isNext before Reset:"; arr.isNext()
     arr.reset()
-    print "isNext after Reset: "; arr.isNext()
+    print "isNext after Reset:"; arr.isNext()
     for i = 1 to 3
         x = arr.next()
         print x
@@ -33,9 +33,9 @@ sub testAA()
         "c": 3
         "d": "string"
     }
-    print "isNext before Reset: "; aa.isNext()
+    print "isNext before Reset:"; aa.isNext()
     aa.reset()
-    print "isNext after Reset: "; aa.isNext()
+    print "isNext after Reset:"; aa.isNext()
     for i = 1 to 3
         x = aa.next()
         print x
@@ -49,15 +49,15 @@ sub testAA()
     end while
 
     bb = {}
-    print "isEmpty: "; bb.isNext()
-    print "isNext Empty: "; bb.isNext()
+    print "isEmpty:"; bb.isNext()
+    print "isNext Empty:"; bb.isNext()
     bb.addReplace("a", 10)
     bb.addReplace("b", -2)
     bb.addReplace("c", "core")
     bb.addReplace("d", 4.4)
-    print "isNext before Reset: "; bb.isNext()
+    print "isNext before Reset:"; bb.isNext()
     bb.reset()
-    print "isNext after Reset: "; bb.isNext()
+    print "isNext after Reset:"; bb.isNext()
     for i = 1 to 3
         x = bb.next()
         print x

--- a/test/e2e/resources/components/ifEnum.brs
+++ b/test/e2e/resources/components/ifEnum.brs
@@ -1,0 +1,74 @@
+sub main()
+    testArray()
+    testAA()
+end sub
+
+sub testArray()
+    print "testing roArray ifEnum"
+    arr = [1,2,3]
+    print "isNext Not Empty: "; arr.isNext()
+    arr.clear()
+    print "isEmpty: "; arr.isEmpty()
+    print "isNext Empty: "; arr.isNext()
+    arr.push("a")
+    arr.push("b")
+    arr.push("c")
+    arr.push("d")
+    print "isNext before Reset: "; arr.isNext()
+    arr.reset()
+    print "isNext after Reset: "; arr.isNext()
+    for i = 1 to 3
+        x = arr.next()
+        print x
+    next
+    arr.unshift("x")
+    print arr.next()
+end sub
+
+sub testAA()
+    print "testing AA ifEnum"
+    aa = {
+        "a": 9
+        "b": 5
+        "c": 3
+        "d": "string"
+    }
+    print "isNext before Reset: "; aa.isNext()
+    aa.reset()
+    print "isNext after Reset: "; aa.isNext()
+    for i = 1 to 3
+        x = aa.next()
+        print x
+    next
+    aa.addReplace("9", 0)
+    aa.addReplace("x", -10)
+    x= aa.next()
+    while x <> invalid
+        print x
+        x = aa.next()
+    end while
+
+    bb = {}
+    print "isEmpty: "; bb.isNext()
+    print "isNext Empty: "; bb.isNext()
+    bb.addReplace("a", 10)
+    bb.addReplace("b", -2)
+    bb.addReplace("c", "core")
+    bb.addReplace("d", 4.4)
+    print "isNext before Reset: "; bb.isNext()
+    bb.reset()
+    print "isNext after Reset: "; bb.isNext()
+    for i = 1 to 3
+        x = bb.next()
+        print x
+    next
+    bb.addReplace("x", -10)
+    bb.addReplace("9", 0)
+    print "Reset()"
+    bb.reset()
+    x = bb.next()
+    while x <> invalid
+        print x
+        x = bb.next()
+    end while
+end sub


### PR DESCRIPTION
This PR implements:
- Methods from `ifEnum`: `isNext()`, `next()`, `reset()` (array and AA)
- Sort AA items when printing the object (same behavior as Roku)
- Unit Tests