### PR TITLE
fix(lib): Component XML path parsing was failing on edge case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/settings.json
 lib/
 types/
 node_modules/

--- a/src/componentprocessor/index.ts
+++ b/src/componentprocessor/index.ts
@@ -87,9 +87,9 @@ export async function getComponentDefinitionMap(
     additionalDirs: string[] = [],
     libraryName: string | undefined
 ) {
-    let searchString = "{components}";
+    let searchString = "{components, }";
     if (additionalDirs.length) {
-        searchString = `{components, ${additionalDirs.join(",")}}`;
+        searchString = `{components,${additionalDirs.join(",")}}`;
     }
     const componentsPattern = path.join(rootDir, searchString, "**", "*.xml");
     const xmlFiles: string[] = fg.sync(componentsPattern, {});

--- a/src/componentprocessor/index.ts
+++ b/src/componentprocessor/index.ts
@@ -87,7 +87,10 @@ export async function getComponentDefinitionMap(
     additionalDirs: string[] = [],
     libraryName: string | undefined
 ) {
-    let searchString = `{components,${additionalDirs.join(",")}}`;
+    let searchString = "{components}";
+    if (additionalDirs.length) {
+        searchString = `{components, ${additionalDirs.join(",")}}`;
+    }
     const componentsPattern = path.join(rootDir, searchString, "**", "*.xml");
     const xmlFiles: string[] = fg.sync(componentsPattern, {});
 
@@ -108,11 +111,13 @@ async function processXmlTree(
     // create map of just ComponentDefinition objects
     nodeDefs.map((item) => {
         if (item.isFulfilled && !item.isRejected) {
-            let name = item.value!.name!.toLowerCase();
+            let name = item.value?.name?.toLowerCase();
             if (libraryName) {
                 name = `${libraryName.toLowerCase()}:${name}`;
             }
-            nodeDefMap.set(name, item.value!);
+            if (name) {
+                nodeDefMap.set(name, item.value!);
+            }
         }
     });
 

--- a/test/componentprocessor/componentprocessor.test.js
+++ b/test/componentprocessor/componentprocessor.test.js
@@ -35,7 +35,7 @@ describe("component parsing support", () => {
 
         it("only searches components if no custom directories", async () => {
             fg.sync.mockImplementation((pattern, options) => {
-                expect(pattern.includes("{components,}")).toBeTruthy();
+                expect(pattern.includes("{components, }")).toBeTruthy();
                 return [];
             });
 


### PR DESCRIPTION
When parsing an empty list of additional directories, the code was finding invalid XML files under `node_modules` when the package was installed in posix OS (Mac, Linux).