### PR TITLE
Fixed #38 - Improved context handling for Callables

### DIFF
--- a/src/brsTypes/Callable.ts
+++ b/src/brsTypes/Callable.ts
@@ -142,6 +142,9 @@ export class Callable implements Brs.BrsValue {
     /** The signature of this callable within the BrightScript runtime. */
     readonly signatures: SignatureAndImplementation[];
 
+    /** The context (m) that this callable is running under (if `undefined` is running on root m) */
+    private context: Brs.RoAssociativeArray | undefined;
+
     /**
      * Calls the function this `Callable` represents with the provided `arg`uments using the
      * provided `Interpreter` instance.
@@ -214,6 +217,14 @@ export class Callable implements Brs.BrsValue {
 
     getName(): string {
         return this.name || "";
+    }
+
+    getContext() {
+        return this.context;
+    }
+
+    setContext(context: Brs.RoAssociativeArray) {
+        this.context = context;
     }
 
     /**

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -232,9 +232,12 @@ describe("end to end syntax", () => {
         await execute([resourceFile("dot-chaining.brs")], outputStreams);
 
         expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
-            "removed number '3' from array, remaining 2",
-            "promise-like resolved to 'foo'",
+            "removed number '7' from array, remaining 6",
+            "removed number '6' from array, remaining 5",
+            "promise-like resolved to 'success'",
             "optional chaining works",
+            "param test result was: success",
+            "literal test result was: success",
         ]);
     });
     test("try-catch.brs", async () => {

--- a/test/e2e/resources/dot-chaining.brs
+++ b/test/e2e/resources/dot-chaining.brs
@@ -1,13 +1,44 @@
 sub main()
-    a = [" 1 ", " 2 ", " 3 "]
+    a = [" 1 ", " 2 ", " 3 ", " 4 ", " 5 ", " 6 ", " 7 "]
     b = a.pop().trim().toInt()
     print "removed number '" + b.toStr() + "' from array, remaining " + a.count().toStr()
-    m.__result = "bad"
-    immediatePromise("foo").then(sub(result)
+    c = (a.pop()).trim().toInt()
+    print "removed number '" + c.toStr() + "' from array, remaining " + a.count().toStr()
+    m.__result = "fail"
+    immediatePromise("success").then(sub(result)
         print "promise-like resolved to '" + result + "'"
     end sub)
     print "optional chaining " + testOptionalChaining()
+    m.name = "root"
+    level1 = {name: "level1", param: "param test result was: "}
+    level1.run = sub()
+        print createLevel2().testResult(m.param)
+        print createLevel2().testResult("literal test result was: ")
+    end sub
+    level1.run()
 end sub
+
+function createLevel2()
+    instance = __level2_builder()
+    instance.new()
+    return instance
+end function
+
+function __level2_builder()
+    instance = {name: "level2"}
+    instance.new = sub()
+        m.name = "newName"
+    end sub
+    instance.testResult = function(param) as string
+         if m.name = "newName"
+            result = "success"
+        else
+            result = "fail"
+        end if
+        return param + result
+    end function
+    return instance
+end function
 
 ' A simple promise-like function that immediately resolves to the provided value.
 ' You probably don't want to use it in production.


### PR DESCRIPTION
The original solution to identify the context (m object) for Callables was relying on re-evaluating the source on a dot chained call, that had performance issues, and caused the side effect of issue #9, the solution I implemented for it was partial, and did not solved the performance issue fully. 

Now I did saved a reference for the context for each callable, eliminating the need of re-evaluation, and fixed all side effects.

I added a couple of. new scenarios to the e2e test cases.