### PR TITLE
Fixed #41 - Global functions `GetInterface()` and `FindMemberFunction()` are not properly boxing parameters

### DIFF
--- a/src/brsTypes/BrsInterface.ts
+++ b/src/brsTypes/BrsInterface.ts
@@ -11,7 +11,13 @@ export class BrsInterface implements BrsValue {
     readonly methodNames: Set<string>;
 
     constructor(readonly name: string, methods: Callable[]) {
-        this.methodNames = new Set(methods.filter((m) => m.name).map((m) => m.name!));
+        this.methodNames = new Set(
+            methods.filter((m) => m.name?.toLowerCase()).map((m) => m.name?.toLowerCase()!)
+        );
+    }
+
+    hasMethod(method: string): boolean {
+        return this.methodNames.has(method.toLowerCase());
     }
 
     toString(): string {

--- a/src/brsTypes/components/RoInt.ts
+++ b/src/brsTypes/components/RoInt.ts
@@ -20,10 +20,10 @@ export class roInt extends BrsComponent implements BrsValue, Unboxable {
         this.intrinsic = initialValue;
         this.registerMethods({
             ifInt: [this.getInt, this.setInt],
-            ifToStr: [this.toStr],
             // Per https://developer.roku.com/docs/references/brightscript/interfaces/ifintops.md,
             // ifIntOps _also_ implements toStr()
             ifIntOps: [this.toStr],
+            ifToStr: [this.toStr],
         });
     }
 

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -130,6 +130,10 @@ describe("end to end standard libary", () => {
             "<Interface: ifFloat>",
             "<Interface: ifAssociativeArray>",
             "<Interface: ifSGNodeDict>",
+            "<Interface: ifStringOps>",
+            "<Interface: ifStringOps>",
+            "<Interface: ifIntOps>",
+            "<Interface: ifToStr>",
         ]);
     });
 });

--- a/test/e2e/resources/stdlib/global-utilities.brs
+++ b/test/e2e/resources/stdlib/global-utilities.brs
@@ -3,4 +3,8 @@ sub main()
     print getInterface(1.123, "ifFloat")
     print findMemberFunction({}, "count")
     print findMemberFunction(node, "findNode")
+    print FindMemberFunction("", "left")
+    print GetInterface("", "ifStringOps")
+    print FindMemberFunction(1, "tostr")
+    print GetInterface(1, "iftostr")
 end sub


### PR DESCRIPTION
Both of the methods `GetInterface()` and `FindMemberFunction()` were not properly boxing parameters to behave like a Roku device.