### PR TITLE
Fixed #8 -Arithmetic Operator Modulo behavior to match Roku

### DIFF
--- a/src/brsTypes/Double.ts
+++ b/src/brsTypes/Double.ts
@@ -89,9 +89,9 @@ export class Double implements Numeric, Comparable, Boxable {
             case ValueKind.Int32:
             case ValueKind.Float:
             case ValueKind.Double:
-                return new Double(this.getValue() % rhs.getValue());
+                return new Double(Math.trunc(this.getValue() % rhs.getValue()));
             case ValueKind.Int64:
-                return new Double(this.getValue() % rhs.getValue().toNumber());
+                return new Double(Math.trunc(this.getValue() % rhs.getValue().toNumber()));
         }
     }
 

--- a/src/brsTypes/Float.ts
+++ b/src/brsTypes/Float.ts
@@ -99,11 +99,11 @@ export class Float implements Numeric, Comparable, Boxable {
         switch (rhs.kind) {
             case ValueKind.Int32:
             case ValueKind.Float:
-                return new Float(this.getValue() % rhs.getValue());
+                return new Float(Math.trunc(this.getValue() % rhs.getValue()));
             case ValueKind.Double:
-                return new Double(this.getValue() % rhs.getValue());
+                return new Double(Math.trunc(this.getValue() % rhs.getValue()));
             case ValueKind.Int64:
-                return new Float(this.getValue() % rhs.getValue().toNumber());
+                return new Float(Math.trunc(this.getValue() % rhs.getValue().toNumber()));
         }
     }
 

--- a/src/brsTypes/Int32.ts
+++ b/src/brsTypes/Int32.ts
@@ -103,9 +103,9 @@ export class Int32 implements Numeric, Comparable, Boxable {
             case ValueKind.Int32:
                 return new Int32(this.getValue() % rhs.getValue());
             case ValueKind.Float:
-                return new Float(this.getValue() % rhs.getValue());
+                return new Float(Math.trunc(this.getValue() % rhs.getValue()));
             case ValueKind.Double:
-                return new Double(this.getValue() % rhs.getValue());
+                return new Double(Math.trunc(this.getValue() % rhs.getValue()));
             case ValueKind.Int64:
                 return new Int64(this.getValue()).modulo(rhs);
         }

--- a/test/brsTypes/Double.test.js
+++ b/test/brsTypes/Double.test.js
@@ -159,14 +159,14 @@ describe("Double", () => {
             let two = new Int32(2);
             let result = tenPointFive.modulo(two);
             expect(result.kind).toBe(ValueKind.Double);
-            expect(result.getValue()).toBe(0.5);
+            expect(result.getValue()).toBe(0);
         });
 
         it("modulos Int64 right-hand sides", () => {
             let three = new Int64(3);
             let result = tenPointFive.modulo(three);
             expect(result.kind).toBe(ValueKind.Double);
-            expect(result.getValue()).toBe(1.5);
+            expect(result.getValue()).toBe(1);
         });
 
         it("modulos Float right-hand sides", () => {
@@ -180,7 +180,7 @@ describe("Double", () => {
             let twoPointFive = new Double(2.5);
             let result = tenPointFive.modulo(twoPointFive);
             expect(result.kind).toBe(ValueKind.Double);
-            expect(result.getValue()).toBe(0.5);
+            expect(result.getValue()).toBe(0);
         });
     });
 

--- a/test/brsTypes/Float.test.js
+++ b/test/brsTypes/Float.test.js
@@ -159,14 +159,14 @@ describe("Float", () => {
             let two = new Int32(2);
             let result = tenPointFive.modulo(two);
             expect(result.kind).toBe(ValueKind.Float);
-            expect(result.getValue()).toBe(0.5);
+            expect(result.getValue()).toBe(0);
         });
 
         it("modulos Int64 right-hand sides", () => {
             let three = new Int64(3);
             let result = tenPointFive.modulo(three);
             expect(result.kind).toBe(ValueKind.Float);
-            expect(result.getValue()).toBe(1.5);
+            expect(result.getValue()).toBe(1);
         });
 
         it("modulos Float right-hand sides", () => {
@@ -180,7 +180,7 @@ describe("Float", () => {
             let twoPointFive = new Double(2.5);
             let result = tenPointFive.modulo(twoPointFive);
             expect(result.kind).toBe(ValueKind.Double);
-            expect(result.getValue()).toBe(0.5);
+            expect(result.getValue()).toBe(0);
         });
     });
 

--- a/test/brsTypes/Int32.test.js
+++ b/test/brsTypes/Int32.test.js
@@ -192,14 +192,14 @@ describe("Int32", () => {
             let threePointFive = new Float(3.25);
             let result = ten.modulo(threePointFive);
             expect(result.kind).toBe(ValueKind.Float);
-            expect(result.getValue()).toBe(0.25);
+            expect(result.getValue()).toBe(0);
         });
 
         it("modulos Double right-hand sides", () => {
             let twoPointFive = new Double(2.75);
             let result = ten.modulo(twoPointFive);
             expect(result.kind).toBe(ValueKind.Double);
-            expect(result.getValue()).toBe(1.75);
+            expect(result.getValue()).toBe(1);
         });
     });
 

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -72,6 +72,14 @@ describe("end to end syntax", () => {
             "-5", // unary + and -
             " 5",
             "-5",
+            "Float",
+            " 1",
+            "Float",
+            " 1",
+            "Float",
+            " 1",
+            "Integer",
+            " 1",
         ]);
     });
 

--- a/test/e2e/resources/arithmetic.brs
+++ b/test/e2e/resources/arithmetic.brs
@@ -40,3 +40,13 @@ print 32 >> 3
 print -5 ' => -5
 print +5 ' => 5
 print -+-+-+5 ' => -5
+
+' modulo operations
+print type(7.6 mod 3.0) 'Float
+print 7.6 mod 3.0 ' 1
+print type(7 mod 3.0) 'Float
+print 7 mod 3.0 ' 1
+print type(7.6 mod 3) 'Float
+print 7.6 mod 3 ' 1
+print type(7 mod 3) 'Integer
+print 7 mod 3 ' 1

--- a/test/interpreter/Arithmetic.test.js
+++ b/test/interpreter/Arithmetic.test.js
@@ -56,7 +56,7 @@ describe("interpreter arithmetic", () => {
     it("modulos numbers", () => {
         let ast = binary(new brs.types.Int32(2), Lexeme.Mod, new brs.types.Float(1.5));
         let [result] = interpreter.exec([ast]);
-        expect(result.getValue()).toBe(0.5);
+        expect(result.getValue()).toBe(0);
     });
 
     it("exponentiates numbers", () => {


### PR DESCRIPTION
Roku always truncates the result value, not showing decimals event for Float and Double