### PR TITLE
Fixed Unit Tests `.todo` and `.skip`

### DIFF
--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -115,7 +115,9 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
                 returns: ValueKind.Void,
             },
             impl: (_interpreter, s: BrsString, len: Int32) => {
-                this.intrinsic = new BrsString(s.value.substr(0, len.getValue()));
+                const length = len.getValue();
+                this.intrinsic =
+                    length <= 0 ? new BrsString("") : new BrsString(s.value.slice(0, length));
                 return BrsInvalid.Instance;
             },
         }
@@ -140,9 +142,10 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             returns: ValueKind.Void,
         },
         impl: (_interpreter, s: BrsString, len: Int32) => {
-            this.intrinsic = this.intrinsic.concat(
-                new BrsString(s.value.substr(0, len.getValue()))
-            );
+            const length = len.getValue();
+            if (length > 0) {
+                this.intrinsic = this.intrinsic.concat(new BrsString(s.value.slice(0, length)));
+            }
             return BrsInvalid.Instance;
         },
     });
@@ -176,8 +179,9 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             returns: ValueKind.String,
         },
         impl: (_interpreter, len: Int32) => {
-            let source = this.intrinsic.value;
-            return new BrsString(source.substr(source.length - len.getValue()));
+            const source = this.intrinsic.value;
+            const length = len.getValue();
+            return length <= 0 ? new BrsString("") : new BrsString(source.slice(-length));
         },
     });
 
@@ -243,6 +247,9 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
                 returns: ValueKind.Int32,
             },
             impl: (_interpreter, startIndex: Int32, substring: BrsString) => {
+                if (substring.value === "") {
+                    return new Int32(startIndex.getValue() < 0 ? 0 : startIndex.getValue());
+                }
                 return new Int32(
                     this.intrinsic.value.indexOf(substring.value, startIndex.getValue())
                 );

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -239,9 +239,9 @@ describe("RoString", () => {
                     expect(instr.call(interpreter, new BrsString("Fonzie"))).toEqual(new Int32(-1));
                 });
 
-                it.todo("returns 0 for empty substrings");
-                // TODO: compare to RBI
-                // () => expect(instr.call(interpreter, new BrsString(""))).toEqual(new Int32(-1));
+                it("returns 0 for empty substrings", () => {
+                    expect(instr.call(interpreter, new BrsString(""))).toEqual(new Int32(0));
+                });
             });
 
             describe("with start_index", () => {
@@ -257,9 +257,17 @@ describe("RoString", () => {
                     );
                 });
 
-                it.todo("returns start_index for empty substrings");
-                // TODO: compare to RBI
-                // () => expect(instr.call(interpreter, new BrsString(""))).toEqual(new Int32(-1));
+                it("returns start_index (when positive) for empty substrings", () => {
+                    expect(instr.call(interpreter, new Int32(111), new BrsString(""))).toEqual(
+                        new Int32(111)
+                    );
+                });
+
+                it("returns 0 (when star_index is negative) for empty substrings", () => {
+                    expect(instr.call(interpreter, new Int32(-1), new BrsString(""))).toEqual(
+                        new Int32(0)
+                    );
+                });
             });
         });
 

--- a/test/interpreter/AssignmentOperators.test.js
+++ b/test/interpreter/AssignmentOperators.test.js
@@ -83,18 +83,18 @@ describe("interpreter assignment operators", () => {
         expect(interpreter.environment.get(identifier("foo"))).toEqual(new Int32(1));
     });
 
-    it.skip("left-shifts numbers", () => {
+    it("left-shifts numbers", () => {
         interpreter.exec([
             initializeFoo(new Int32(4)),
             fooAssignmentOperator(token(Lexeme.LeftShiftEqual, "<<="), new Int32(2)),
         ]);
 
-        expect(interpreter.environment.get(identifier("foo"))).toEqual(new Int32(8));
+        expect(interpreter.environment.get(identifier("foo"))).toEqual(new Int32(16));
     });
 
-    it.skip("right-shifts numbers", () => {
+    it("right-shifts numbers", () => {
         interpreter.exec([
-            initializeFoo(new Int32(8)),
+            initializeFoo(new Int32(16)),
             fooAssignmentOperator(token(Lexeme.RightShiftEqual, ">>="), new Int32(2)),
         ]);
 


### PR DESCRIPTION
The `roString`  behavior was not consistent with Roku, fixed the edge cases.