### PR TITLE
Option to suppress color from the console log

### DIFF
--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -93,7 +93,7 @@ export const defaultExecutionOptions: ExecutionOptions = {
     generateCoverage: false,
     componentDirs: [],
     isComponentLibrary: false,
-    noColor: false
+    noColor: false,
 };
 Object.freeze(defaultExecutionOptions);
 

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -81,6 +81,8 @@ export interface ExecutionOptions {
     componentDirs: string[];
     /** Whether or not a component library is being processed. */
     isComponentLibrary: boolean;
+    /** Suppress console colors */
+    noColor: boolean;
 }
 
 /** The default set of execution options.  Includes the `stdout`/`stderr` pair from the process that invoked `brs`. */
@@ -91,6 +93,7 @@ export const defaultExecutionOptions: ExecutionOptions = {
     generateCoverage: false,
     componentDirs: [],
     isComponentLibrary: false,
+    noColor: false
 };
 Object.freeze(defaultExecutionOptions);
 
@@ -454,7 +457,11 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 const toPrint = this.evaluate(printable);
                 const isNumber = isBrsNumber(toPrint) || isBoxedNumber(toPrint);
                 const str = isNumber && this.isPositive(toPrint.getValue()) ? " " : "";
-                this.stdout.write(colorize(str + toPrint.toString()));
+                if (this.options.noColor) {
+                    this.stdout.write(str + toPrint.toString());
+                } else {
+                    this.stdout.write(colorize(str + toPrint.toString()));
+                }
             }
         });
 


### PR DESCRIPTION
The [@hulu/roca](https://github.com/hulu/roca/) project is using the `@rokucommunity/brs` project to help run BrightScript unit tests. Roca uses Jest to run the tests and relies on a [TAP](https://testanything.org/) interface to consume the test output and show the results including pass, fail, total tests, etc. The colorization function in the interpreter sends out the test results with ansi codes. These are not compliant with TAP and produce unexpected results. 

This PR is a simple way to suppress colors when invoking the interpreter outside of the CLI. 