### PR TITLE
Implemented missing methods on `roDateTime`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@types/lolex": "^2.1.3",
         "@types/long": "^3.0.32",
         "@types/memory-fs": "^0.3.2",
-        "@types/node": "^8.5.2",
+        "@types/node": "^22.13.2",
         "@types/p-settle": "^2.0.1",
         "@types/uuid": "^8.3.0",
         "@types/xmldoc": "^1.1.4",
@@ -50,7 +50,7 @@
         "rimraf": "^2.6.2",
         "tslint": "^5.11.0",
         "tslint-config-prettier": "^1.18.0",
-        "typescript": "4"
+        "typescript": "^5.7.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1166,10 +1166,14 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "8.10.66",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
-      "dev": true
+      "version": "22.15.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.9.tgz",
+      "integrity": "sha512-l6QaCgJSJQ0HngL1TjvEY2DlefKggyGeXP1KYvYLBX41ZDPM1FsgDMAr5c+T673NMy7VCptMOzXOuJqf5uB0bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -9474,16 +9478,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -9515,6 +9520,13 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg==",
       "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unherit": {
       "version": "1.1.3",
@@ -11088,10 +11100,13 @@
       }
     },
     "@types/node": {
-      "version": "8.10.66",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
-      "dev": true
+      "version": "22.15.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.9.tgz",
+      "integrity": "sha512-l6QaCgJSJQ0HngL1TjvEY2DlefKggyGeXP1KYvYLBX41ZDPM1FsgDMAr5c+T673NMy7VCptMOzXOuJqf5uB0bA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -17390,9 +17405,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true
     },
     "unbox-primitive": {
@@ -17420,6 +17435,12 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "unherit": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/lolex": "^2.1.3",
     "@types/long": "^3.0.32",
     "@types/memory-fs": "^0.3.2",
-    "@types/node": "^8.5.2",
+    "@types/node": "^22.13.2",
     "@types/p-settle": "^2.0.1",
     "@types/uuid": "^8.3.0",
     "@types/xmldoc": "^1.1.4",
@@ -67,7 +67,7 @@
     "rimraf": "^2.6.2",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "4"
+    "typescript": "^5.7.3"
   },
   "repository": "https://github.com/rokucommunity/brs",
   "jest": {

--- a/src/brsTypes/components/RoDateTime.ts
+++ b/src/brsTypes/components/RoDateTime.ts
@@ -526,7 +526,7 @@ export class RoDateTime extends BrsComponent implements BrsValue {
  */
 function wrapTokens(input: string, tokens: string[]): string {
     const tokenRegex = new RegExp(`(${tokens.join("|")})`, "g");
-    return input.replace(tokenRegex, (match, token, offset, string) => {
+    return input.replace(tokenRegex, (_, token: string, offset: number, string) => {
         const before = string[offset - 1];
         const after = string[offset + token.length];
         if (before && /[a-zA-Z0-9]/.test(before) && after && /[a-zA-Z0-9]/.test(after)) {

--- a/src/brsTypes/index.ts
+++ b/src/brsTypes/index.ts
@@ -148,6 +148,15 @@ export function isStringComp(value: BrsType): value is BrsString & Comparable {
     return isBrsString(value) || value instanceof RoPath;
 }
 
+/**
+ * Determines whether or not the given value can be compared as a number.
+ * @param value the BrightScript value in question.
+ * @returns `true` if `value` can be compared as a number, otherwise `false`.
+ */
+export function isNumberComp(value: BrsType): value is BrsType & Comparable {
+    return isBrsNumber(value) || isBoxedNumber(value);
+}
+
 /** Determines whether or not the given value is a BrightScript boxed number.
  * @param value the BrightScript value in question.
  * @returns `true` if `value` is a boxed number, otherwise `false`.

--- a/test/brsTypes/components/RoDateTime.test.js
+++ b/test/brsTypes/components/RoDateTime.test.js
@@ -1,5 +1,6 @@
 const brs = require("../../../lib");
-const { RoDateTime, Int32, BrsString, BrsInvalid } = brs.types;
+const { Uninitialized } = require("../../../lib/brsTypes/BrsType");
+const { RoDateTime, Int32, Int64, BrsString, BrsInvalid } = brs.types;
 const { Interpreter } = require("../../../lib/interpreter");
 const lolex = require("lolex");
 
@@ -43,7 +44,7 @@ describe("RoDateTime", () => {
                 let result = mark.call(interpreter);
                 expect(mark).toBeTruthy();
                 expect(dt.markTime).toEqual(clock.now);
-                expect(result).toBe(BrsInvalid.Instance);
+                expect(result).toBe(Uninitialized.Instance);
             });
         });
 
@@ -146,6 +147,15 @@ describe("RoDateTime", () => {
             });
         });
 
+        describe("asSecondsLong", () => {
+            it("returns the date/time as the number of seconds from the Unix epoch as Long Integer", () => {
+                let asSeconds = dt.getMethod("asSecondsLong");
+                let result = asSeconds.call(interpreter);
+                expect(asSeconds).toBeTruthy();
+                expect(result).toEqual(new Int64(1230768000));
+            });
+        });
+
         describe("fromISO8601String", () => {
             it("set the date/time using a string in the ISO 8601 format", () => {
                 let fromISO8601String = dt.getMethod("fromISO8601String");
@@ -155,7 +165,7 @@ describe("RoDateTime", () => {
                     new BrsString("2019-07-27T17:08:41")
                 );
                 expect(new Int32(dt.markTime)).toEqual(new Int32(1564247321000));
-                expect(result).toBe(BrsInvalid.Instance);
+                expect(result).toBe(Uninitialized.Instance);
             });
 
             it("set the date/time using an invalid string", () => {
@@ -163,7 +173,7 @@ describe("RoDateTime", () => {
                 expect(fromISO8601String).toBeTruthy();
                 let result = fromISO8601String.call(interpreter, new BrsString("garbage"));
                 expect(new Int32(dt.markTime)).toEqual(new Int32(0));
-                expect(result).toBe(BrsInvalid.Instance);
+                expect(result).toBe(Uninitialized.Instance);
             });
         });
 
@@ -172,6 +182,16 @@ describe("RoDateTime", () => {
                 let fromSeconds = dt.getMethod("fromSeconds");
                 expect(fromSeconds).toBeTruthy();
                 let result = fromSeconds.call(interpreter, new Int32(1564247321));
+                expect(new Int32(dt.markTime)).toEqual(new Int32(1564247321000));
+                expect(result).toBe(Uninitialized.Instance);
+            });
+        });
+
+        describe("fromSecondsLong", () => {
+            it("set the date/time value using the number of seconds from the Unix epoch as Long Integer", () => {
+                let fromSeconds = dt.getMethod("fromSecondsLong");
+                expect(fromSeconds).toBeTruthy();
+                let result = fromSeconds.call(interpreter, new Int64(2550877200));
                 expect(new Int32(dt.markTime)).toEqual(new Int32(1564247321000));
                 expect(result).toBe(BrsInvalid.Instance);
             });
@@ -292,7 +312,7 @@ describe("RoDateTime", () => {
                 let local = 1230768000123 - new Date(1230768000123).getTimezoneOffset() * 60 * 1000;
                 expect(toLocalTime).toBeTruthy();
                 expect(new Int32(dt.markTime)).toEqual(new Int32(local));
-                expect(result).toBe(BrsInvalid.Instance);
+                expect(result).toBe(Uninitialized.Instance);
             });
         });
     });

--- a/test/brsTypes/components/RoDateTime.test.js
+++ b/test/brsTypes/components/RoDateTime.test.js
@@ -138,6 +138,26 @@ describe("RoDateTime", () => {
             });
         });
 
+        describe("asDateStringLoc", () => {
+            it("returns date string localized in 'short' format", () => {
+                let asDateStringLoc = dt.getMethod("asDateStringLoc");
+
+                let result = asDateStringLoc.call(interpreter, new BrsString("short"));
+                expect(asDateStringLoc).toBeTruthy();
+                expect(result).toEqual(new BrsString("1/1/09"));
+            });
+        });
+
+        describe("asTimeStringLoc", () => {
+            it("returns time string localized in 'short' format", () => {
+                let asTimeStringLoc = dt.getMethod("asTimeStringLoc");
+
+                let result = asTimeStringLoc.call(interpreter, new BrsString("short"));
+                expect(asTimeStringLoc).toBeTruthy();
+                expect(result).toEqual(new BrsString("12:00 am"));
+            });
+        });
+
         describe("asSeconds", () => {
             it("returns the date/time as the number of seconds from the Unix epoch", () => {
                 let asSeconds = dt.getMethod("asSeconds");

--- a/test/parser/controlFlow/__snapshots__/For.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/For.test.js.snap
@@ -67,6 +67,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 0,
         },
@@ -85,6 +86,7 @@ Array [
       },
       "type": "Literal",
       "value": Int32 {
+        "inArray": false,
         "kind": 4,
         "value": 5,
       },
@@ -102,6 +104,7 @@ Array [
       },
       "type": "Literal",
       "value": Int32 {
+        "inArray": false,
         "kind": 4,
         "value": 2,
       },
@@ -244,6 +247,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 0,
         },
@@ -262,6 +266,7 @@ Array [
       },
       "type": "Literal",
       "value": Int32 {
+        "inArray": false,
         "kind": 4,
         "value": 5,
       },
@@ -279,6 +284,7 @@ Array [
       },
       "type": "Literal",
       "value": Int32 {
+        "inArray": false,
         "kind": 4,
         "value": 1,
       },
@@ -406,6 +412,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 0,
         },
@@ -424,6 +431,7 @@ Array [
       },
       "type": "Literal",
       "value": Int32 {
+        "inArray": false,
         "kind": 4,
         "value": 5,
       },
@@ -441,6 +449,7 @@ Array [
       },
       "type": "Literal",
       "value": Int32 {
+        "inArray": false,
         "kind": 4,
         "value": 1,
       },

--- a/test/parser/controlFlow/__snapshots__/If.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/If.test.js.snap
@@ -18,6 +18,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -36,6 +37,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -149,6 +151,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 1,
             },
@@ -167,6 +170,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 2,
             },
@@ -255,6 +259,7 @@ Array [
                 },
                 "type": "Literal",
                 "value": Int32 {
+                  "inArray": false,
                   "kind": 4,
                   "value": 3,
                 },
@@ -492,6 +497,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -510,6 +516,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -743,6 +750,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -761,6 +769,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -1082,6 +1091,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -1100,6 +1110,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -1213,6 +1224,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 1,
             },
@@ -1231,6 +1243,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 2,
             },
@@ -1319,6 +1332,7 @@ Array [
                 },
                 "type": "Literal",
                 "value": Int32 {
+                  "inArray": false,
                   "kind": 4,
                   "value": 3,
                 },
@@ -1959,6 +1973,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -1977,6 +1992,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -2104,6 +2120,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -2122,6 +2139,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -2387,6 +2405,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -2405,6 +2424,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -2890,6 +2910,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -2907,6 +2928,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -3015,6 +3037,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 1,
             },
@@ -3032,6 +3055,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 2,
             },
@@ -3392,6 +3416,7 @@ Array [
                   },
                   "type": "Literal",
                   "value": Int32 {
+                    "inArray": false,
                     "kind": 4,
                     "value": 1,
                   },
@@ -4590,6 +4615,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -4607,6 +4633,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -4760,6 +4787,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -4777,6 +4805,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -5014,6 +5043,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -5031,6 +5061,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -5139,6 +5170,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 1,
             },
@@ -5156,6 +5188,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 2,
             },
@@ -5834,6 +5867,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -5852,6 +5886,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -6245,6 +6280,7 @@ Array [
                 },
                 "type": "Literal",
                 "value": Int32 {
+                  "inArray": false,
                   "kind": 4,
                   "value": 1,
                 },
@@ -6263,6 +6299,7 @@ Array [
                 },
                 "type": "Literal",
                 "value": Int32 {
+                  "inArray": false,
                   "kind": 4,
                   "value": 0,
                 },
@@ -6361,6 +6398,7 @@ Array [
                     },
                     "type": "Literal",
                     "value": Int32 {
+                      "inArray": false,
                       "kind": 4,
                       "value": 1,
                     },
@@ -6379,6 +6417,7 @@ Array [
                     },
                     "type": "Literal",
                     "value": Int32 {
+                      "inArray": false,
                       "kind": 4,
                       "value": 0,
                     },
@@ -6677,6 +6716,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -6695,6 +6735,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },

--- a/test/parser/controlFlow/__snapshots__/While.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/While.test.js.snap
@@ -122,6 +122,7 @@ Array [
                     },
                     "type": "Literal",
                     "value": Int32 {
+                      "inArray": false,
                       "kind": 4,
                       "value": 1000,
                     },
@@ -261,6 +262,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 1000,
               },
@@ -400,6 +402,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1000,
         },

--- a/test/parser/expression/__snapshots__/Additive.test.js.snap
+++ b/test/parser/expression/__snapshots__/Additive.test.js.snap
@@ -53,6 +53,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 1,
           },
@@ -70,6 +71,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 2,
           },
@@ -105,6 +107,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 3,
         },
@@ -184,6 +187,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 1,
           },
@@ -201,6 +205,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 2,
           },
@@ -236,6 +241,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 3,
         },

--- a/test/parser/expression/__snapshots__/ArrayLiterals.test.js.snap
+++ b/test/parser/expression/__snapshots__/ArrayLiterals.test.js.snap
@@ -70,6 +70,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 1,
             },
@@ -87,6 +88,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 2,
             },
@@ -255,6 +257,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 1,
               },
@@ -272,6 +275,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 2,
               },
@@ -289,6 +293,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 3,
               },
@@ -343,6 +348,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 4,
               },
@@ -360,6 +366,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 5,
               },
@@ -377,6 +384,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 6,
               },
@@ -492,6 +500,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 1,
           },
@@ -509,6 +518,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 2,
           },
@@ -526,6 +536,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 3,
           },
@@ -778,6 +789,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 1,
           },
@@ -795,6 +807,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 2,
           },
@@ -812,6 +825,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 3,
           },
@@ -908,6 +922,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 1,
           },
@@ -925,6 +940,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 2,
           },
@@ -942,6 +958,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 3,
           },
@@ -1038,6 +1055,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 1,
           },
@@ -1055,6 +1073,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 2,
           },
@@ -1072,6 +1091,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 3,
           },

--- a/test/parser/expression/__snapshots__/AssociativeArrayLiterals.test.js.snap
+++ b/test/parser/expression/__snapshots__/AssociativeArrayLiterals.test.js.snap
@@ -74,6 +74,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 1,
             },
@@ -97,6 +98,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 2,
             },
@@ -120,6 +122,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 3,
             },
@@ -260,6 +263,7 @@ Array [
                     },
                     "type": "Literal",
                     "value": Int32 {
+                      "inArray": false,
                       "kind": 4,
                       "value": 3,
                     },
@@ -575,6 +579,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 1,
             },
@@ -598,6 +603,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 2,
             },
@@ -621,6 +627,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 3,
             },
@@ -723,6 +730,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 1,
             },
@@ -746,6 +754,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 2,
             },
@@ -769,6 +778,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 3,
             },
@@ -871,6 +881,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 1,
             },
@@ -894,6 +905,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 2,
             },
@@ -917,6 +929,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 3,
             },

--- a/test/parser/expression/__snapshots__/Call.test.js.snap
+++ b/test/parser/expression/__snapshots__/Call.test.js.snap
@@ -18,6 +18,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 1,
           },
@@ -35,6 +36,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 2,
           },

--- a/test/parser/expression/__snapshots__/Exponential.test.js.snap
+++ b/test/parser/expression/__snapshots__/Exponential.test.js.snap
@@ -52,6 +52,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -69,6 +70,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 3,
         },
@@ -148,6 +150,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 2,
           },
@@ -165,6 +168,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 3,
           },
@@ -200,6 +204,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 4,
         },

--- a/test/parser/expression/__snapshots__/Function.test.js.snap
+++ b/test/parser/expression/__snapshots__/Function.test.js.snap
@@ -236,6 +236,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 3,
             },
@@ -296,6 +297,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 4,
             },
@@ -376,6 +378,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 5,
               },
@@ -956,6 +959,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 3,
             },
@@ -1035,6 +1039,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 5,
               },
@@ -1759,6 +1764,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 3,
             },
@@ -1819,6 +1825,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 4,
             },
@@ -1899,6 +1906,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 5,
               },
@@ -2479,6 +2487,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 3,
             },
@@ -2558,6 +2567,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 5,
               },

--- a/test/parser/expression/__snapshots__/Indexing.test.js.snap
+++ b/test/parser/expression/__snapshots__/Indexing.test.js.snap
@@ -69,6 +69,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 6,
           },
@@ -105,6 +106,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 0,
             },
@@ -141,6 +143,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 2,
               },
@@ -345,6 +348,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 0,
             },
@@ -468,6 +472,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 2,
           },
@@ -649,6 +654,7 @@ Array [
           },
           "type": "Literal",
           "value": Int32 {
+            "inArray": false,
             "kind": 4,
             "value": 2,
           },

--- a/test/parser/expression/__snapshots__/PrefixUnary.test.js.snap
+++ b/test/parser/expression/__snapshots__/PrefixUnary.test.js.snap
@@ -153,6 +153,7 @@ Array [
                   },
                   "type": "Literal",
                   "value": Int32 {
+                    "inArray": false,
                     "kind": 4,
                     "value": 5,
                   },
@@ -309,6 +310,7 @@ Array [
                 },
                 "type": "Literal",
                 "value": Int32 {
+                  "inArray": false,
                   "kind": 4,
                   "value": 5,
                 },
@@ -463,6 +465,7 @@ Array [
                 },
                 "type": "Literal",
                 "value": Int32 {
+                  "inArray": false,
                   "kind": 4,
                   "value": 5,
                 },
@@ -703,6 +706,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 5,
         },
@@ -781,6 +785,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 5,
         },

--- a/test/parser/expression/__snapshots__/Primary.test.js.snap
+++ b/test/parser/expression/__snapshots__/Primary.test.js.snap
@@ -52,6 +52,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },
@@ -71,6 +72,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 2,
             },
@@ -88,6 +90,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 3,
             },
@@ -219,6 +222,7 @@ Array [
       },
       "type": "Literal",
       "value": Int32 {
+        "inArray": false,
         "kind": 4,
         "value": 5,
       },

--- a/test/parser/expression/__snapshots__/Relational.test.js.snap
+++ b/test/parser/expression/__snapshots__/Relational.test.js.snap
@@ -52,6 +52,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 5,
         },
@@ -69,6 +70,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -147,6 +149,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 5,
         },
@@ -164,6 +167,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -242,6 +246,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 5,
         },
@@ -259,6 +264,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -337,6 +343,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 5,
         },
@@ -354,6 +361,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -432,6 +440,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 5,
         },
@@ -449,6 +458,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },
@@ -527,6 +537,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 5,
         },
@@ -544,6 +555,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 2,
         },

--- a/test/parser/statement/__snapshots__/AssignmentOperators.test.js.snap
+++ b/test/parser/statement/__snapshots__/AssignmentOperators.test.js.snap
@@ -71,6 +71,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 3,
         },
@@ -265,6 +266,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 4,
         },
@@ -362,6 +364,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 6,
         },
@@ -459,6 +462,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 7,
         },
@@ -556,6 +560,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 5,
         },
@@ -653,6 +658,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 1,
         },

--- a/test/parser/statement/__snapshots__/Block.test.js.snap
+++ b/test/parser/statement/__snapshots__/Block.test.js.snap
@@ -130,6 +130,7 @@ Array [
                 },
                 "type": "Literal",
                 "value": Int32 {
+                  "inArray": false,
                   "kind": 4,
                   "value": 0,
                 },
@@ -149,6 +150,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 10,
               },
@@ -167,6 +169,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 1,
               },
@@ -375,6 +378,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 1,
               },

--- a/test/parser/statement/__snapshots__/Declaration.test.js.snap
+++ b/test/parser/statement/__snapshots__/Declaration.test.js.snap
@@ -52,6 +52,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 5,
         },
@@ -69,6 +70,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 3,
         },
@@ -146,6 +148,7 @@ Array [
       },
       "type": "Literal",
       "value": Int32 {
+        "inArray": false,
         "kind": 4,
         "value": 5,
       },

--- a/test/parser/statement/__snapshots__/Function.test.js.snap
+++ b/test/parser/statement/__snapshots__/Function.test.js.snap
@@ -59,6 +59,7 @@ Object {
                 },
                 "type": "Literal",
                 "value": Int32 {
+                  "inArray": false,
                   "kind": 4,
                   "value": 1,
                 },
@@ -174,6 +175,7 @@ Object {
                 },
                 "type": "Literal",
                 "value": Int32 {
+                  "inArray": false,
                   "kind": 4,
                   "value": 1,
                 },
@@ -289,6 +291,7 @@ Object {
                 },
                 "type": "Literal",
                 "value": Int32 {
+                  "inArray": false,
                   "kind": 4,
                   "value": 1,
                 },
@@ -404,6 +407,7 @@ Object {
                 },
                 "type": "Literal",
                 "value": Int32 {
+                  "inArray": false,
                   "kind": 4,
                   "value": 1,
                 },
@@ -539,6 +543,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 3,
             },
@@ -599,6 +604,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 4,
             },
@@ -679,6 +685,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 5,
               },
@@ -1162,6 +1169,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 3,
             },
@@ -1241,6 +1249,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 5,
               },
@@ -2367,6 +2376,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 3,
             },
@@ -2427,6 +2437,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 4,
             },
@@ -2507,6 +2518,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 5,
               },
@@ -2990,6 +3002,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 3,
             },
@@ -3069,6 +3082,7 @@ Array [
               },
               "type": "Literal",
               "value": Int32 {
+                "inArray": false,
                 "kind": 4,
                 "value": 5,
               },

--- a/test/parser/statement/__snapshots__/Set.test.js.snap
+++ b/test/parser/statement/__snapshots__/Set.test.js.snap
@@ -33,6 +33,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 0,
         },
@@ -90,6 +91,7 @@ Array [
             },
             "type": "Literal",
             "value": Int32 {
+              "inArray": false,
               "kind": 4,
               "value": 0,
             },
@@ -130,6 +132,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 3,
         },
@@ -189,6 +192,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 0,
         },
@@ -303,6 +307,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 0,
         },
@@ -477,6 +482,7 @@ Array [
         },
         "type": "Literal",
         "value": Int32 {
+          "inArray": false,
           "kind": 4,
           "value": 5,
         },


### PR DESCRIPTION
This PR fixes #90 by adding the following missing methods to `roDateTime`:
- asDateStringLoc
- asTimeStringLoc
- asSecondsLong
- fromSecondsLong

Also merged the `Int32` and `Int64` improvements from `brs-engine`